### PR TITLE
erc20-doc-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 .cache
 .vagrant
 .sass-cache
+vendor/
+.bundle/
 
 # YARD artifacts
 .yardoc

--- a/source/includes/_erc20tokenstatsv2.md
+++ b/source/includes/_erc20tokenstatsv2.md
@@ -22,7 +22,6 @@ ERC20 tokens we currently support are:
 | Kyber Network         | `knc`   |
 | iExec RLC             | `rlc`   |
 | ChainLink             | `link`  |
-| Ocean Protocol        | `ocean` |
 | Fetch.ai.             | `fet`   |
 
 ## ERC20 On-chain Volume
@@ -63,6 +62,7 @@ This endpoint returns the full historical on-chain volume of any of the major ER
 | key       | _string_ | Your unique API key                                 |
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the volume for                   |
+| window    | _string_  | `1h` or `1d`                                       |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
@@ -117,6 +117,7 @@ This endpoint returns the number of token transfers on the blockchain for the gi
 | key       | _string_ | Your unique API key                                 |
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the transaction count for        |
+| window    | _string_  | `1h` or `1d`                                       |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
@@ -169,6 +170,7 @@ This endpoint returns the active addresses of ERC20 tokens for every day of thei
 | key       | _string_ | Your unique API key                                 |
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the transaction count for        |
+| window    | _string_  | `1h` or `1d`                                       |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |

--- a/source/includes/_erc20tokenstatsv2.md
+++ b/source/includes/_erc20tokenstatsv2.md
@@ -62,7 +62,7 @@ This endpoint returns the full historical on-chain volume of any of the major ER
 | key       | _string_ | Your unique API key                                 |
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the volume for                   |
-| window    | _string_  | `1h` or `1d`                                       |
+| window    | _string_  | `1d` (no support for 1h at this time)              |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
@@ -117,7 +117,7 @@ This endpoint returns the number of token transfers on the blockchain for the gi
 | key       | _string_ | Your unique API key                                 |
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the transaction count for        |
-| window    | _string_  | `1h` or `1d`                                       |
+| window    | _string_  | `1d` (no support for 1h at this time)              |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
@@ -170,7 +170,7 @@ This endpoint returns the active addresses of ERC20 tokens for every day of thei
 | key       | _string_ | Your unique API key                                 |
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the transaction count for        |
-| window    | _string_  | `1h` or `1d`                                       |
+| window    | _string_  | `1d` (no support for 1h at this time)              |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |

--- a/source/includes/_stablecoinstatsv2.md
+++ b/source/includes/_stablecoinstatsv2.md
@@ -57,6 +57,10 @@ This endpoint returns the full historical on-chain volume of Tether on the OMNI 
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | `usdt_omni`                                         |
 | window    | _string_ | `1h` or `1d`                                        |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -109,6 +113,10 @@ This endpoint returns the daily number of Tether (usdt_omni) transactions on the
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | `usdt_omni`                                         |
 | window    | _string_ | `1h` or `1d`                                        |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -158,6 +166,10 @@ This endpoint returns the active addresses of Tether (usdt_omni) tokens for ever
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The stablecoin you want the transaction count for   |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -204,6 +216,10 @@ This endpoint returns the historical supply of Tether (usdt_omni) on the OMNI bl
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | `usdt_omni`                                         |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -249,6 +265,10 @@ This endpoint returns the historical supply of the Tether ERC20 token (usdt_erc2
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | `usdt_erc20`                                         |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -296,6 +316,10 @@ This endpoint returns the NVT Ratio (Network Value to Transactions Ratio) for Te
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | `usdt_omni`                                         |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -348,6 +372,10 @@ This endpoint returns the historical supply of Tether (usdt_omni) on the OMNI bl
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | `usdt_omni`                                         |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -398,6 +426,10 @@ This endpoint returns the full historical on-chain volume of any of the stableco
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The token you want the volume for                   |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -448,6 +480,10 @@ This endpoint returns the number of token transfers on the Ethereum blockchain f
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The stablecoin you want the transaction count for   |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 
@@ -495,6 +531,10 @@ This endpoint returns the active addresses of stabelecoin tokens for every day o
 | format    | _string_ | What format you want your data in (`json` or `csv`) |
 | token     | _string_ | The stablecoin you want the transaction count for   |
 | window    | _string_ | `1d` (no support for 1h at this time)               |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
 
 ### Data Overview
 


### PR DESCRIPTION
In _erc20tokenstatsv2.md:

removed `ocean` 
added lines of `window` 
added directories to ignore in .gitignore  due to bundle install not working in environment, but bundle install --path vendor/bundle works

erc20-doc-update-2:

tested out 1d/1h; only accepts 1d. 
tested stablecoins accepts 1h/1d 

stablecoins-from-to-limit-update

added from_date, to_date and limit to the query parameters. Tested on all sections under stablecoins and works.