### PR TITLE
ETH miner-specific hashrate and rewards  + Corrected names in miner to exchanges

### DIFF
--- a/source/includes/_btcminerstats.md
+++ b/source/includes/_btcminerstats.md
@@ -331,8 +331,8 @@ curl "https://api.tokenanalyst.io/analytics/private/v1/entity_to_entity_flow_win
 | format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
 | token        | _string_  | `btc`                                                                                     |                                       |
 | window       | _string_  | `1h` or `1d`                                                                              |
-| from_entity  | _string_  | A miner from the <a href="https://docs.tokenanalyst.io/#miners-to-exchanges-full-historical-flows" target="_self">table</a> that we support
-| to_entity    | _string_  | An exchange from the <a href="https://docs.tokenanalyst.io/#miners-to-exchanges-full-historical-flows" target="_self">table</a> that we support
+| from_entity  | _string_  | A miner from the <a href="https://docs.tokenanalyst.io/#btc-miners-to-exchanges-full-historical-flows" target="_self">table</a> that we support
+| to_entity    | _string_  | An exchange from the <a href="https://docs.tokenanalyst.io/#btc-miners-to-exchanges-full-historical-flows" target="_self">table</a> that we support
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -1,5 +1,135 @@
 # Ethereum Miner Stats
 
+For Ethereum _Miner Hashrate_ and _Miner Rewards_ endpoints, the supported miners/mining pools in the query parameter `miner` are:
+
+| Miner Name     | `miner`           | 
+|----------------|-------------------|
+| BitClubPool    | `bitclubpool`     |
+| Coinotron3     | `coinotron3`      |
+| DwarfPool1     | `dwarfpool1`      |
+| Ethermine      | `ethermine`       |
+| Ethpool2       | `ethpool2`        |
+| F2Pool2        | `f2pool2`         |
+| MiningPoolHub  | `miningpoolhub`   |
+| NanoPool       | `nanopool`        |
+| SparkPool      | `sparkpool`       |
+| Zhizhu.top     | `zhizhu-top`      |
+| Others         | `others`          |
+| Unknown        | `unknown`         |
+
+Miner addresses that we have identified but are not supported have a `miner` name of `others`. Similarly, miner addresses that are unlabelled have a `miner` name of `unknown`
+
+## Miner Hashrate
+
+This endpoint returns the daily miner specific hashrates for all the miners we cover. 
+The `hashrate` are denominated in TH/s. The `block_count` are the number of blocks mined by a specific miner.
+
+<img src="https://img.shields.io/badge/Tier-Hobbyist-blue.svg"/>
+
+```shell
+curl "https://api.tokenanalyst.io/analytics/private/v1/token_miner_hashrate_window_historical/last?format=json&miner=nanopool&token=eth&window=1d&from_date=2020-01-22&to_date=2020-01-23&limit=2&key=API_KEY"
+```
+```json
+[
+  {
+    "date": "2020-01-22",
+    "hashrate": ,
+    "block_count": ,
+    "hashrate_pct": 
+  },
+  {
+    "date": "2020-01-23",
+    "hashrate": ,
+    "block_count": ,
+    "hashrate_pct": 
+  }
+]
+```
+
+### HTTP Request
+
+`GET https://api.tokenanalyst.io/analytics/private/v1/token_miner_hashrate_window_historical/last`
+
+### Query Parameters
+
+| Parameter    | Type      | Description                                                                               |
+| ------------ | --------- | ----------------------------------------------------------------------------------------- |
+| key          | _string_  | Your unique API key                                                                       |
+| format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
+| token        | _string_  | `eth`                                                                                     |
+| miner        | _miner_   | A miner from the <a href="https://docs.tokenanalyst.io/#ethereum-miner-stats" target="_self">table</a> that we support                                                              |
+| window       | _string_  | `1d` (no support for 1h at this time)                                                     |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
+Note: All params with a \* are optional and `limit` is only available in the JSON return format
+
+### Data Overview
+
+| Field                    | Type      | Description                                                                                                         |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------- |
+| date                     | _string_  | The date in _YYYY-MM-DD_                                                                                            |
+| hashrate                 | _decimal_ | The hashrate contribution of a given miner for the day. Denominated in Th/s.                                      |
+| block_count              | _integer_ | The total number of blocks mined by a given miner on this date                                                          |
+| hashrate_pct             | _decimal_ | The percentage of the daily hashrate contributed by the miner. (_miner_daily_hashrate_/_total_daily_hashrate_)\*100 |
+
+## Miner Rewards
+
+<img src="https://img.shields.io/badge/Tier-Hobbyist-blue.svg"/>
+
+```shell
+curl "https://api.tokenanalyst.io/analytics/private/v1/token_miner_rewards_window_historical/last?format=json&miner=nanopool&token=eth&window=1d&from_date=2020-01-22&to_date=2020-01-23&limit=2&key=API_KEY"
+
+```
+
+> The above command returns JSON structured like this:
+
+```json
+[
+  {
+    "date": "2020-01-22",
+    "block_reward": ,
+    "block_reward_usd": 
+  },
+  {
+    "date": "2020-01-23",
+    "block_reward": ,
+    "block_reward_usd": 
+  }
+]
+```
+
+This endpoint returns the daily rewards earned by all the miners we cover (incl. uncle rewards). The `block_reward` is denominated ETH.
+
+### HTTP Request
+
+`GET https://api.tokenanalyst.io/analytics/private/v1/token_miner_rewards_window_historical/last`
+
+### Query Parameters
+
+| Parameter    | Type      | Description                                                                               |
+| ------------ | --------- | ----------------------------------------------------------------------------------------- |
+| key          | _string_  | Your unique API key                                                                       |
+| format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
+| token        | _string_  | `eth`                                                                                     |
+| miner        | _string_  | A miner from the <a href="https://docs.tokenanalyst.io/#ethereum-miner-stats" target="_self">table</a> that we support                                                    |
+| window       | _string_  | `1d` only. `1h` not supported currently.                                                  |
+| from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
+| to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
+| limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
+
+Note: All params with a \* are optional and `limit` is only available in the JSON return format
+
+### Data Overview
+
+| Field                        | Type      | Description                                                                              |
+| ---------------------------- | --------- | ---------------------------------------------------------------------------------------- |
+| date                         | _string_  | The date in _YYYY-MM-DD_                                                                 |
+| block_reward                 | _decimal_ | The total amount of block rewards earned by a given miner on this date. Denominated in ETH. |
+| block_reward_usd             | _decimal_ | _block_reward_ \* _price_usd_                                                            |
+
+
 ## Miners to Exchanges Full Historical Flows
 
 This endpoint returns the full historical flows of ETH from miners _to_ exchanges that we have labelled.
@@ -96,3 +226,4 @@ Note: All params with a \* are optional and `limit` is only available in the JSO
 | number_of_txns    | _integer_ | The number of transactions sending ETH into an exchange on this date/hour                                                             |
 | value             | _decimal_ | The total value of transactions sending ETH into an exchange                                                                          |
 | value_usd         | _decimal_ | The USD value of transactions sending ETH into an exchange                                                                            |
+

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -137,25 +137,14 @@ For Ethereum, the currently supported Exchanges/Miners are:
 
 | Name             | `to_entity`        | `from_entity`                                                    |
 | ---------------- | ------------------ | ---------------------------------------------------------------- |
-| 2 Miners PPLNS   | `2minerspplns`     | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
-| 2 Miners SOLO    | `2minerssolo`      | `binance`, `bittrex`                                             |
-| AltPool.Pro      | `altpool-pro`      | `binance`                                                        |
-| BTC.COM          | `btc-compool`      | `binance`, `bittrex`, `kraken`                                   |
-| Baikalmine       | `baikalmine1`      | `bittrex`                                                        |
-| Beeppool         | `beeppool`         | `binance`, `bittrex`                                             |
 | Coinotron        | `coinotron3`       | `binance`, `bitfinex`, `bittrex`, `kraken`, `poloniex`           |
-| Cruxpool         | `cruxpool`         | `binance`, `kraken`                                              |
 | Dwarfpool        | `dwarfpool1`       | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
-| eth.solopool.org | `eth-solopool-org` | `binance`, `bittrex`                                             |
 | Ethermine        | `ethermine`        | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
 | Ethpool          | `ethpool2`         | `binance`, `kraken`                                              |
 | F2 Pool          | `f2pool2`          | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
-| Minerall         | `minerallpool`     | `binance`, `bittrex`, `kraken`, `poloniex`                       |
 | Miningpoolhub    | `miningpoolhub`    | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
 | Nanopool         | `nanopool`         | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
 | Sparkpool        | `sparkpool`        | `bitfinex`                                                       |
-| Uleypool         | `uleypool`         | `binance`                                                        |
-| W pool           | `wpool`            | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
 | zhizhu.top       | `zhizhu-top`       | `binance`, `bittrex`                                             |
 
 The above table defines supported pairs of the query parameters `to_entity` and `from_entity`.

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -163,7 +163,7 @@ The above table defines supported pairs of the query parameters `to_entity` and 
 <img src="https://img.shields.io/badge/Tier-Professional-black.svg"/>
 
 ```shell
-curl "https://api.tokenanalyst.io/analytics/private/v1/entity_to_entity_flow_window_historical/last?ormat=json&to_entity=binance&from_entity=2miners:%20pplns&token=eth&window=1h&limit=2&key=APIKEY"
+curl "https://api.tokenanalyst.io/analytics/private/v1/entity_to_entity_flow_window_historical/last?ormat=json&to_entity=binance&from_entity=2minerspplns&token=eth&window=1h&limit=2&key=APIKEY"
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -33,15 +33,15 @@ curl "https://api.tokenanalyst.io/analytics/private/v1/token_miner_hashrate_wind
 [
   {
     "date": "2020-01-22",
-    "hashrate": ,
-    "block_count": ,
-    "hashrate_pct": 
+    "hashrate": 12.5367,
+    "block_count": 518,
+    "hashrate_pct": 8.003
   },
   {
     "date": "2020-01-23",
-    "hashrate": ,
-    "block_count": ,
-    "hashrate_pct": 
+    "hashrate": 12.533,
+    "block_count": 522,
+    "hashrate_pct": 7.9325
   }
 ]
 ```
@@ -89,13 +89,13 @@ curl "https://api.tokenanalyst.io/analytics/private/v1/token_miner_rewards_windo
 [
   {
     "date": "2020-01-22",
-    "block_reward": ,
-    "block_reward_usd": 
+    "block_reward": 1091.75,
+    "block_reward_usd": 183502.22
   },
   {
     "date": "2020-01-23",
-    "block_reward": ,
-    "block_reward_usd": 
+    "block_reward": 1100.3125,
+    "block_reward_usd": 179312.62
   }
 ]
 ```

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -19,7 +19,7 @@ For Ethereum _Miner Hashrate_ and _Miner Rewards_ endpoints, the supported miner
 
 Miner addresses that we have identified but are not supported have a `miner` name of `others`. Similarly, miner addresses that are unlabelled have a `miner` name of `unknown`
 
-## Miner Hashrate
+## ETH Miner Hashrate
 
 This endpoint returns the daily miner specific hashrates for all the miners we cover. 
 The `hashrate` are denominated in TH/s. The `block_count` are the number of blocks mined by a specific miner.
@@ -57,7 +57,7 @@ curl "https://api.tokenanalyst.io/analytics/private/v1/token_miner_hashrate_wind
 | key          | _string_  | Your unique API key                                                                       |
 | format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
 | token        | _string_  | `eth`                                                                                     |
-| miner        | _miner_   | A miner from the <a href="https://docs.tokenanalyst.io/#ethereum-miner-stats" target="_self">table</a> that we support                                                              |
+| miner        | _miner_   | A miner from the [table](#ethereum-miner-stats) that we support                                                              |
 | window       | _string_  | `1d` (no support for 1h at this time)                                                     |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
@@ -74,7 +74,7 @@ Note: All params with a \* are optional and `limit` is only available in the JSO
 | block_count              | _integer_ | The total number of blocks mined by a given miner on this date                                                          |
 | hashrate_pct             | _decimal_ | The percentage of the daily hashrate contributed by the miner. (_miner_daily_hashrate_/_total_daily_hashrate_)\*100 |
 
-## Miner Rewards
+## ETH Miner Rewards
 
 <img src="https://img.shields.io/badge/Tier-Hobbyist-blue.svg"/>
 
@@ -113,7 +113,7 @@ This endpoint returns the daily rewards earned by all the miners we cover (incl.
 | key          | _string_  | Your unique API key                                                                       |
 | format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
 | token        | _string_  | `eth`                                                                                     |
-| miner        | _string_  | A miner from the <a href="https://docs.tokenanalyst.io/#ethereum-miner-stats" target="_self">table</a> that we support                                                    |
+| miner        | _string_  | A miner from the [table](#ethereum-miner-stats) that we support                                                    |
 | window       | _string_  | `1d` only. `1h` not supported currently.                                                  |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
@@ -129,8 +129,7 @@ Note: All params with a \* are optional and `limit` is only available in the JSO
 | block_reward                 | _decimal_ | The total amount of block rewards earned by a given miner on this date. Denominated in ETH. |
 | block_reward_usd             | _decimal_ | _block_reward_ \* _price_usd_                                                            |
 
-
-## Miners to Exchanges Full Historical Flows
+## ETH Miners to Exchanges Full Historical Flows
 
 This endpoint returns the full historical flows of ETH from miners _to_ exchanges that we have labelled.
 
@@ -206,8 +205,8 @@ curl "https://api.tokenanalyst.io/analytics/private/v1/entity_to_entity_flow_win
 | format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
 | token        | _string_  | `eth`                                                                                     |  |
 | window       | _string_  | `1h` or `1d`                                                                              |
-| from_entity  | _string_  | A miner from the table that we support                                                    |
-| to_entity    | _string_  | An exchange from the table that we support                                                |
+| from_entity  | _string_  | A miner from the <a href="https://docs.tokenanalyst.io/##eth-miners-to-exchanges-full-historical-flows" target="_self">table</a> that we support                                                    |
+| to_entity    | _string_  | An exchange from the <a href="https://docs.tokenanalyst.io/##eth-miners-to-exchanges-full-historical-flows" target="_self">table</a> that we support                                                |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |
 | limit \*     | _integer_ | The number of entries returned before the latest data point (or the to_date if specified) |
@@ -226,4 +225,3 @@ Note: All params with a \* are optional and `limit` is only available in the JSO
 | number_of_txns    | _integer_ | The number of transactions sending ETH into an exchange on this date/hour                                                             |
 | value             | _decimal_ | The total value of transactions sending ETH into an exchange                                                                          |
 | value_usd         | _decimal_ | The USD value of transactions sending ETH into an exchange                                                                            |
-

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -137,26 +137,26 @@ For Ethereum, the currently supported Exchanges/Miners are:
 
 | Name             | `to_entity`        | `from_entity`                                                    |
 | ---------------- | ------------------ | ---------------------------------------------------------------- |
-| 2 Miners PPLNS   | `2miners: pplns`   | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
-| 2 Miners SOLO    | `2miners: solo`    | `binance`, `bittrex`                                             |
-| AltPool.Pro      | `altpool.pro`      | `binance`                                                        |
-| BTC.COM          | `btc.com pool`     | `binance`, `bittrex`, `kraken`                                   |
-| Baikalmine       | `baikalmine 1`     | `bittrex`                                                        |
+| 2 Miners PPLNS   | `2minerspplns`     | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
+| 2 Miners SOLO    | `2minerssolo`      | `binance`, `bittrex`                                             |
+| AltPool.Pro      | `altpool-pro`      | `binance`                                                        |
+| BTC.COM          | `btc-compool`      | `binance`, `bittrex`, `kraken`                                   |
+| Baikalmine       | `baikalmine1`      | `bittrex`                                                        |
 | Beeppool         | `beeppool`         | `binance`, `bittrex`                                             |
-| Coinotron        | `coinotron 3`      | `binance`, `bitfinex`, `bittrex`, `kraken`, `poloniex`           |
+| Coinotron        | `coinotron3`       | `binance`, `bitfinex`, `bittrex`, `kraken`, `poloniex`           |
 | Cruxpool         | `cruxpool`         | `binance`, `kraken`                                              |
-| Dwarfpool        | `dwarfpool 1`      | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
-| eth.solopool.org | `eth.solopool.org` | `binance`, `bittrex`                                             |
+| Dwarfpool        | `dwarfpool1`       | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
+| eth.solopool.org | `eth-solopool-org` | `binance`, `bittrex`                                             |
 | Ethermine        | `ethermine`        | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
-| Ethpool          | `ethpool 2`        | `binance`, `kraken`                                              |
-| F2 Pool          | `f2pool 2`         | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
-| Minerall         | `minerall pool`    | `binance`, `bittrex`, `kraken`, `poloniex`                       |
+| Ethpool          | `ethpool2`         | `binance`, `kraken`                                              |
+| F2 Pool          | `f2pool2`          | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
+| Minerall         | `minerallpool`     | `binance`, `bittrex`, `kraken`, `poloniex`                       |
 | Miningpoolhub    | `miningpoolhub`    | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
 | Nanopool         | `nanopool`         | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`, `poloniex` |
-| Sparkpool        | `spark pool`       | `bitfinex`                                                       |
+| Sparkpool        | `sparkpool`        | `bitfinex`                                                       |
 | Uleypool         | `uleypool`         | `binance`                                                        |
-| W pool           | `w pool`           | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
-| zhizhu.top       | `zhizhu.top`       | `binance`, `bittrex`                                             |
+| W pool           | `wpool`            | `binance`, `bitfinex`, `bittrex`, `kraken`, `kucoin`             |
+| zhizhu.top       | `zhizhu-top`       | `binance`, `bittrex`                                             |
 
 The above table defines supported pairs of the query parameters `to_entity` and `from_entity`.
 

--- a/source/includes/_ethminerstats.md
+++ b/source/includes/_ethminerstats.md
@@ -70,8 +70,8 @@ Note: All params with a \* are optional and `limit` is only available in the JSO
 | Field                    | Type      | Description                                                                                                         |
 | ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------- |
 | date                     | _string_  | The date in _YYYY-MM-DD_                                                                                            |
-| hashrate                 | _decimal_ | The hashrate contribution of a given miner for the day. Denominated in Th/s.                                      |
-| block_count              | _integer_ | The total number of blocks mined by a given miner on this date                                                          |
+| hashrate                 | _decimal_ | The hashrate contribution of a given miner for the day. Denominated in Th/s.                                        |
+| block_count              | _integer_ | The total number of blocks mined by a given miner on this date                                                      |
 | hashrate_pct             | _decimal_ | The percentage of the daily hashrate contributed by the miner. (_miner_daily_hashrate_/_total_daily_hashrate_)\*100 |
 
 ## ETH Miner Rewards
@@ -113,7 +113,7 @@ This endpoint returns the daily rewards earned by all the miners we cover (incl.
 | key          | _string_  | Your unique API key                                                                       |
 | format       | _string_  | What format you want your data in (`json` or `csv`)                                       |
 | token        | _string_  | `eth`                                                                                     |
-| miner        | _string_  | A miner from the [table](#ethereum-miner-stats) that we support                                                    |
+| miner        | _string_  | A miner from the [table](#ethereum-miner-stats) that we support                           |
 | window       | _string_  | `1d` only. `1h` not supported currently.                                                  |
 | from_date \* | _string_  | Start date of returned data specified as YYYY-MM-DD (ISO date format)                     |
 | to_date \*   | _string_  | End date of returned data specified as YYYY-MM-DD (ISO date format)                       |


### PR DESCRIPTION
Added:
Miner specific hashrate
Mienr specific rewards
Links that direct users to the table of parameters

Corrected:
Fixed up the miner-to-exchanges miner names to reflect removal of spaces, colons etc.